### PR TITLE
donate help v4 (#247)

### DIFF
--- a/commands/base_commands/social.py
+++ b/commands/base_commands/social.py
@@ -2618,12 +2618,17 @@ class CmdDonate(ArxCommand):
         +donate/score [<group>]
 
     Donates money to some group of npcs in exchange for prestige.
-    +donate/score lists donation amounts. Costs 1 AP.
     """
     key = "+donate"
     locks = "cmd:all()"
     help_category = "Social"
     action_point_cost = 1
+
+    def get_help(self, caller, cmdset):
+        msg = self.__doc__ + """
+    +donate/score lists donation amounts. Costs {w%s{n AP.
+    """ % (action_point_cost)
+        return msg
 
     @property
     def donations(self):

--- a/commands/cmdsets/home.py
+++ b/commands/cmdsets/home.py
@@ -1196,7 +1196,7 @@ class CmdBuyFromShop(CmdCraft):
             except (TypeError, ValueError, KeyError):
                 caller.msg("You must supply the ID number of an item being sold.")
                 return
-            if price > caller.db.currency:
+            if price - (price * (self.get_discount() / 100.0)) > caller.db.currency:
                 caller.msg("You cannot afford it.")
                 return
             self.buy_item(obj)


### PR DESCRIPTION
* Update social.py

Updated Donate helpfile
'Costs 5 AP' changed to 'Costs 1 AP'

* Automate Helpfile

Alters the donate helpfile so that it will automatically update the AP value the helpfile lists in the future, should the cost to run the command ever change again.

A slightly more complex test run to be sure I'm doing this right.

* Update social.py

* Revert "Update social.py"

This reverts commit 1f29713b60fa3c4755dd2b938fc2185d05ac6b53.

* Revert "Automate Helpfile"

This reverts commit a10a5f41440812781f31300a0f9cea4c828fcf30.

* Update social.py

* Update social.py

* Update home.py

* Update social.py

* Update home.py

* Update home.py

Reverted the change due to the Travis CI error. Not a valid way to write this solution.

#### Brief overview of PR changes/additions

#### Motivation for adding to Arx

#### Other info (issues closed, discussion etc)
